### PR TITLE
fixed a bug in getMagnitude() for VectorInt16

### DIFF
--- a/DMP_Image.h
+++ b/DMP_Image.h
@@ -563,7 +563,7 @@ class VectorInt16 {
 
 
   float getMagnitude() {
-    return sqrt(x*x + y*y + z*z);
+    return sqrt((float)x*(float)x + (float)y*(float)y + (float)z*(float)z);
   }
 
   VectorInt16 :: normalize() {


### PR DESCRIPTION
casting x, y and z components of VectorInt16 to float first when calculating the magnitude. This avoids errors when using large values.